### PR TITLE
Added region attribute to provider/resource

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'meringu@gmail.com'
 license          'All rights reserved'
 description      'Recource wrapper for remote_file and aws_s3_file'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.3'
+version          '0.1.4'
 
 depends          'aws'
 

--- a/providers/default.rb
+++ b/providers/default.rb
@@ -36,6 +36,7 @@ def do_remote_or_s3_file(resource_action)
       aws_access_key_id new_resource.aws_access_key_id unless new_resource.aws_access_key_id.nil?
       aws_secret_access_key new_resource.aws_secret_access_key unless new_resource.aws_secret_access_key.nil?
       aws_session_token new_resource.aws_session_token unless new_resource.aws_session_token.nil?
+      region new_resource.region unless new_resource.region.nil?
       action resource_action
     end
   else

--- a/resources/default.rb
+++ b/resources/default.rb
@@ -12,3 +12,4 @@ attribute :backup, kind_of: [Integer, FalseClass], default: 5
 attribute :aws_access_key_id, kind_of: String
 attribute :aws_secret_access_key, kind_of: String
 attribute :aws_session_token, kind_of: String
+attribute :region, kind_of: String

--- a/test/cookbooks/remote_or_s3_file_test/recipes/default.rb
+++ b/test/cookbooks/remote_or_s3_file_test/recipes/default.rb
@@ -8,3 +8,11 @@ remote_or_s3_file '/var/install' do
   aws_secret_access_key node['aws']['aws_secret_access_key']
   aws_session_token node['aws']['aws_session_token']
 end
+
+remote_or_s3_file '/var/install2' do
+  source 's3://aws-codedeploy-ap-southeast-2/latest/install'
+  aws_access_key_id node['aws']['aws_access_key_id']
+  aws_secret_access_key node['aws']['aws_secret_access_key']
+  aws_session_token node['aws']['aws_session_token']
+  region 'ap-southeast-2'
+end

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -7,3 +7,7 @@ end
 describe file('/var/install') do
   it { should be_file }
 end
+
+describe file('/var/install2') do
+  it { should be_file }
+end


### PR DESCRIPTION
Pulling an S3 file currently default to the default AWS region. With buckets that are not in this region, this causes 400 errors. This PR allows specifying the AWS region in the resource.
